### PR TITLE
✨ add antigen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "third-party/BurntSushi-ripgrep"]
 	path = third-party/BurntSushi-ripgrep
 	url = ../../BurntSushi/ripgrep
+[submodule "third-party/antigen"]
+	path = third-party/antigen
+	url = ../../zsh-users/antigen.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,11 @@ script:
       py-commit-checker --emojis &&
       DOTFILES_INSTALL_ALL=y ./install
     "
+
+  # pr builds, lint the commits
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    docker run -v"$(pwd):/mnt/workspace" -e TRAVIS_BRANCH -t dotfiles /bin/bash -c
+    "
+      cd /mnt/workspace &&
+      PY_COMMIT_CHECKER_ARGS=--emojis py-commit-checker-branch origin/$TRAVIS_BRANCH
+    "; fi'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     sudo
 
 # install py-commit-checker
-RUN pip install py-commit-checker==0.2.1
+RUN pip install py-commit-checker==0.3.0
 
 # Install vscode for code extension setup test
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \

--- a/install-extras.sh
+++ b/install-extras.sh
@@ -74,21 +74,6 @@ if [ "$DOTFILES_INSTALL_ZSH_PLUGINS" == "y" ]; then
             --depth=1 --branch master https://github.com/robbyrussell/oh-my-zsh.git "$ZSH"
     fi
 
-    # oh-my-zsh plugins; hard-coded to $ZSH install location.
-    # specify specific known-working shas to use
-    conditional_git_install \
-        "$ZSH/custom/plugins/zsh-z" \
-        https://github.com/agkozak/zsh-z \
-        99f6ee91187ad6469b2cc3858f5a60c68286a1a5
-    conditional_git_install \
-        "$ZSH/custom/themes/powerlevel10k" \
-        https://github.com/romkatv/powerlevel10k.git \
-        806ec183ffae5829451405b372c5bce37a83dfa3
-    conditional_git_install \
-        "$ZSH/custom/plugins/zsh-autosuggestions" \
-        https://github.com/zsh-users/zsh-autosuggestions \
-        d43c309f888153d6c46d8b6a3a0186f4148680fd
-
     # tmux plugin manager
     conditional_git_install \
         ~/.tmux/plugins/tpm \

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -6,6 +6,7 @@
 - clean: ['~']
 
 - link:
+    ~/antigen.zsh: third-party/antigen/bin/antigen.zsh
     ~/.config/Code/User/settings.json: vscode/settings.json
     ~/.config/git/ignore: git/ignore
     ~/.config/nvim/init.vim: vim/.vimrc

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -65,27 +65,27 @@ COMPLETION_WAITING_DOTS="true"
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
-# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# Add wisely, as too many plugins slow down shell startup.
-plugins=(
-    cargo
-    colored-man-pages
-    common-aliases
-    git
-    wd
-    zsh-autosuggestions
-    zsh-z
-)
-
 # Disable checking for insecure completions, to speed up shell load
 ZSH_DISABLE_COMPFIX=true
 
 # Load completions
 fpath+=~/.zfunc
 
-source $ZSH/oh-my-zsh.sh
+# Antigen managed plugins
+source ~/antigen.zsh
+
+antigen use oh-my-zsh
+
+antigen bundle agkozak/zsh-z
+antigen bundle cargo
+antigen bundle colored-man-pages
+antigen bundle common-aliases
+antigen bundle git
+antigen bundle wd
+antigen bundle zsh-users/zsh-autosuggestions
+antigen theme romkatv/powerlevel10k
+
+antigen apply
 
 # Autoload Zsh functions. Just enabling zcalc for now, the others may cause
 # overreliance on zsh!


### PR DESCRIPTION
Use antigen to manage plugins.

Seems to speed up prompt reload by about 10ms too, somehow:

```bash
 # no antigen
❯ hyperfine -w 3 -r 25 "zsh -i -c exit"
Benchmark #1: zsh -i -c exit
  Time (mean ± σ):      68.5 ms ±   1.9 ms    [User: 51.8 ms, System: 21.1 ms]
  Range (min … max):    66.5 ms …  73.7 ms    25 runs

 # antigen
❯ hyperfine -w 3 -r 25 "zsh -i -c exit"
Benchmark #1: zsh -i -c exit
  Time (mean ± σ):      58.3 ms ±   0.7 ms    [User: 43.0 ms, System: 19.7 ms]
  Range (min … max):    57.1 ms …  60.0 ms    25 runs
```

Fixes #13.